### PR TITLE
Support for extracting outermost client from X-Forwarded-For

### DIFF
--- a/lib/Mojolicious/Plugin/AccessLog.pm
+++ b/lib/Mojolicious/Plugin/AccessLog.pm
@@ -150,6 +150,10 @@ uname_helper is DEPRECATED in favor of \$c->req->env->{REMOTE_USER} at $f line $
 
     my $servername_cb = sub { $_[3]->base->host || '-' };
     my $remoteaddr_cb = sub { $_[0]->remote_address || '-' };
+    my $remoteaddr_xff_cb = sub {
+        my $xff = $_[0]->req->headers->header('X-Forwarded-For');
+        (split /, /, ($xff || '-'))[0];
+    };
     my %char_handler = (
         '%' => '%',
         a => $remoteaddr_cb,
@@ -192,6 +196,7 @@ uname_helper is DEPRECATED in favor of \$c->req->env->{REMOTE_USER} at $f line $
         U => sub { $_[3]->path },
         v => $servername_cb,
         V => $servername_cb,
+        x => $remoteaddr_xff_cb,
     );
 
     if ($conf->{hostname_lookups}) {
@@ -464,6 +469,16 @@ The name of the server serving the request.
 =item %V
 
 The name of the server serving the request.
+
+=item %x
+
+The outermost ("real") client ip address as found in the
+L<X-Forwared-For|https://en.wikipedia.org/wiki/X-Forwarded-For> header,
+such as one that would be set in an environment with one or more
+layers of ssl- or cache-proxying. When C<X-Forwarded-For> is set to
+I<172.16.0.2, 127.0.0.1> C<%x> would interpolate to I<172.16.0.2>,
+whereas C<%h> would interpolate to I<127.0.0.1>. To get the full
+header use C<%{X-Forwarded-For}i>.
 
 =back
 

--- a/lib/Mojolicious/Plugin/AccessLog.pm
+++ b/lib/Mojolicious/Plugin/AccessLog.pm
@@ -473,10 +473,10 @@ The name of the server serving the request.
 =item %x
 
 The outermost ("real") client ip address as found in the
-L<X-Forwared-For|https://en.wikipedia.org/wiki/X-Forwarded-For> header,
+L<X-Forwarded-For|https://en.wikipedia.org/wiki/X-Forwarded-For> header,
 such as one that would be set in an environment with one or more
 layers of ssl- or cache-proxying. When C<X-Forwarded-For> is set to
-I<172.16.0.2, 127.0.0.1> C<%x> would interpolate to I<172.16.0.2>,
+eg. I<172.16.0.2, 127.0.0.1>, C<%x> would interpolate to I<172.16.0.2>,
 whereas C<%h> would interpolate to I<127.0.0.1>. To get the full
 header use C<%{X-Forwarded-For}i>.
 

--- a/t/10-x-forwarded-for.t
+++ b/t/10-x-forwarded-for.t
@@ -1,0 +1,83 @@
+#!/usr/bin/env perl
+
+use Mojo::Base -strict;
+
+# Disable IPv6 and libev
+BEGIN {
+    $ENV{MOJO_NO_IPV6} = 1;
+    $ENV{MOJO_REACTOR} = 'Mojo::Reactor::Poll';
+}
+
+use lib 't/lib';
+
+use Test::More;
+
+use Mojolicious::Lite;
+use Test::Mojo;
+
+{
+    package Logger;
+
+    sub new {
+        my ($class, $logref) = @_;
+        bless $logref, $class;
+    }
+
+    sub print {
+        my $self = shift;
+
+        $$self = join '', @_;
+    }
+
+    sub peek { ${$_[0]} }
+}
+
+# and now disable log output written with Mojo::Log methods
+app->log->unsubscribe('message');
+
+my $log = Logger->new(\my $b);
+
+plugin 'AccessLog', log => $log, format => '%x %h "%{X-Forwarded-For}i"';
+
+any '/' => sub { $_[0]->render(text => 'done'); };
+
+my $t = Test::Mojo->new;
+
+sub logs_ok {
+	my ($method, $url, $code, $opts, $expects_log) = @_;
+	my $m = $t->can($method . '_ok')
+	  or return fail "Cannot $method $url";
+	$m->($t, $url, $opts)->status_is($code);
+	my $l = $log->peek;
+	chomp $l;
+	is($l, $expects_log);
+}
+
+# Request with no XFF-header
+logs_ok(
+	get => '/' => 200,
+	{},
+	'- 127.0.0.1 "-"');
+
+# Request with XFF set but only one client in chain
+logs_ok(
+	get => '/' => 200,
+	{'X-Forwarded-For' => '127.0.0.1'},
+	'127.0.0.1 127.0.0.1 "127.0.0.1"');
+
+# Request with XFF and two clients in chain
+logs_ok(
+	get => '/' => 200,
+	{'X-Forwarded-For' => '172.16.0.2, 127.0.0.1'},
+	'172.16.0.2 127.0.0.1 "172.16.0.2, 127.0.0.1"');
+
+# Request with upstream proxy mangling XFF. A note on this:
+# It is not our responsibility to make sure that upstream follows
+# the XFF-spec. Instead of hard-failing when there is invalid data
+# set in the header we do as requested and log the value.
+logs_ok(
+	get => '/' => 200,
+	{'X-Forwarded-For' => '172.16.0.2 127.0.0.1'},
+	'172.16.0.2 127.0.0.1 127.0.0.1 "172.16.0.2 127.0.0.1"');
+
+done_testing;


### PR DESCRIPTION
These two commits add support for using `%x` in the log format to extract the outermost client as set in the `X-Forwarded-For` header. This is useful in situations where you have multiple proxy-layers and perhaps already log the header with `%{X-Forwarded-For}i` but would like to have the convenience of logging the client ip in a separate field, for example instead of using `%h`.

I have tried to follow conventions already present in the code of this module, but feel free to point out any discrepancies or things that would need correcting for this pull-request to be accepted.