### PR TITLE
Fix a variable overriding/redefinition bug

### DIFF
--- a/lib/Mojolicious/Plugin/AccessLog.pm
+++ b/lib/Mojolicious/Plugin/AccessLog.pm
@@ -47,8 +47,8 @@ sub register {
         eval { $log->autoflush(1) };
         $logger = sub { $log->print($_[0]) };
     }
-    elsif (blessed($log) and my $l = $log->can('print') || $log->can('info')) {
-        $logger = sub { $l->($log, $_[0]) };
+    elsif (blessed($log) and my $m = $log->can('print') || $log->can('info')) {
+        $logger = sub { $m->($log, $_[0]) };
     }
     elsif ($reftype eq 'CODE') {
         $logger = $log;


### PR DESCRIPTION
A variable named `$l` is used for working purpose in an if statement, but this destroys the previously defined variable with the same name that holds a source line number because they are in the same scope. A subsequent use of the line number variable causes a crash.

The solution implemented here is to rename the work variable.

Thanks for considering it.